### PR TITLE
Feature/step17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'pry-byebug'
 gem 'hirb'         # モデルの出力結果を表形式で表示するGem
 gem 'hirb-unicode' # 日本語などマルチバイト文字の出力時の出力結果のずれに対応
 gem 'rspec-rails'
+gem 'faker'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'rails-i18n'
+gem 'enum_help'
 gem 'factory_bot'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.8.0)
     execjs (2.7.0)
     factory_bot (5.1.2)
@@ -239,6 +241,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  enum_help
   factory_bot
   hirb
   hirb-unicode

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     execjs (2.7.0)
     factory_bot (5.1.2)
       activesupport (>= 4.2.0)
+    faker (2.11.0)
+      i18n (>= 1.6, < 2)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -243,6 +245,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   enum_help
   factory_bot
+  faker
   hirb
   hirb-unicode
   jbuilder (~> 2.5)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,7 +29,6 @@ h2{
 .task_content{
     width:80%;
     background-color:#ffffff;
-    height:80px;
     margin-bottom:20px;
 }
 .detail{

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,26 +12,20 @@
  *
  */
 @import "bootstrap";
-
-.task_wrapper{
-    width:100%;
-    background-color:rgb(39, 123, 192);
-}
-.task_wrap{
-    min-height: 100vh;
-    background-color:gainsboro ;
-    width: 24%;
-    margin-top: 5%;
-}
-h2{
-    margin-top:20px;
-}
-.task_content{
-    width:80%;
-    background-color:#ffffff;
-    margin-bottom:20px;
-}
-.detail{
-    background-color: black;
-    height:100vh;
-}
+.boards__table {
+    tr:hover {
+    cursor: pointer;
+    }
+    }
+    .boards__linkBox {
+    a {
+    margin: 0 8px;
+    }
+    }
+    .boards__searchForm {
+    display: inline-block;
+    }
+    .boards__select {
+    display: inline-block;
+    width: auto;
+    }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -40,6 +40,12 @@ class TasksController < ApplicationController
     redirect_to "/" ,notice:"タスク#{@task.name}を削除しました"
   end
 
+  def search
+    @task = Task.search(params[:search])
+    render 'index'
+  end
+  
+
   private
 
   def task_params

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -43,7 +43,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :detail, :deadline)
+    params.require(:task).permit(:name, :detail, :deadline, :progress)
   end
 
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
     validates :name, presence: true
     validates :detail, length: { minimum: 10 }
+
+    enum progress: {WAITING: 1, WORKING: 2, COMPLETED: 3}
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,4 +3,14 @@ class Task < ApplicationRecord
     validates :detail, length: { minimum: 10 }
 
     enum progress: {WAITING: 1, WORKING: 2, COMPLETED: 3}
+
+    scope :search, -> (search) do
+        
+        return if search.blank?
+
+        name_like(search[:name])
+            .progress_is(search[:progress])
+    end
+    scope :name_like, -> (name) { where('name LIKE ?', "%#{name}%") if name.present?} 
+    scope :progress_is, -> (progress) { where(progress: progress) if progress.present?} 
 end

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -6,7 +6,16 @@
   </div>
   <div class="form-group">
   <%= f.label :detail %>
-  <%= f.text_area :detail, class:"form-control"  %>
+  <%= f.text_area :detail %>
+  </div>
+  <div class="field">
+    <%= f.label :progress %><br />
+    <%= f.label "未着手" %>
+    <%= f.radio_button :progress, :WAITING %>
+    <%= f.label "着手" %>
+    <%= f.radio_button :progress, :WORKING %>
+    <%= f.label "完了" %>
+    <%= f.radio_button :progress, :COMPLETED %>
   </div>
   <div class="form-group">
     <%= f.label :deadline %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,7 +16,7 @@
         <%= tasks.name %><br>
         <%= tasks.detail %><br>
         <%= tasks.deadline %><br>
-        <%= tasks.progress %><br>
+        <%= tasks.progress_i18n %><br>
             </div>
                 <% end %>
     <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,6 +3,21 @@
 <div class="w-25" ><%= flash[:notice]%></div>
 <%= link_to "新規登録", new_task_path, class:"btn btn-light"%>
 
+<div class="search-form">
+        <%= form_with(scope: :search, url: search_tasks_path, method: :get, local: true) do |f| %>
+    <div class="field">
+        <%= f.label :name %>
+        <%= f.text_field :name %>
+    </div>
+    <div class="field">
+        <%= f.label :progress %>
+        <%= f.select :progress, Task.progresses.keys.map {|k| [I18n.t("enums.task.progress.#{k}"), k]}, { include_blank: true} %>
+    </div>
+    <div class="actions">
+        <%= f.submit :search%>
+    </div>
+    <% end %>
+</div>
 <div class="d-flex justify-content-around">
  <div class="task_notstart task_wrap">
     <h2 class="text-center h4">未着手ゾーン</h2>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,52 +1,53 @@
-<div class="bg-primary">
-<div class="container bg-primary">
-<div class="w-25" ><%= flash[:notice]%></div>
-<%= link_to "新規登録", new_task_path, class:"btn btn-light"%>
+<div class="container">
+<div class="d-flex align-items-center">
+<h1>タスク一覧</h1>
+<div class="ml-auto boards__linkBox">
+    <%= form_with(scope: :search, url: search_tasks_path, method: :get, local: true) do |f| %>
+        <div class="field">
+            <%= f.label :name %>
+            <%= f.text_field :name %>
+        </div>
+        <div class="field">
+            <%= f.label :progress %>
+            <%= f.select :progress, Task.progresses.keys.map {|k| [I18n.t("enums.task.progress.#{k}"), k]}, { include_blank: true} %>
+        </div>
+        <div class="actions">
+            <%= f.submit :search%>
+        </div>
+        <% end %>
 
-<div class="search-form">
-        <%= form_with(scope: :search, url: search_tasks_path, method: :get, local: true) do |f| %>
-    <div class="field">
-        <%= f.label :name %>
-        <%= f.text_field :name %>
-    </div>
-    <div class="field">
-        <%= f.label :progress %>
-        <%= f.select :progress, Task.progresses.keys.map {|k| [I18n.t("enums.task.progress.#{k}"), k]}, { include_blank: true} %>
-    </div>
-    <div class="actions">
-        <%= f.submit :search%>
-    </div>
-    <% end %>
-</div>
-<div class="d-flex justify-content-around">
- <div class="task_notstart task_wrap">
-    <h2 class="text-center h4">未着手ゾーン</h2>
+<%= link_to "新規登録", new_task_path, class:"btn btn-light "%>
     <div class="text-center m-2">
-    <%= link_to "昇順", tasks_path(direction:'ASC'), class:"btn btn-light"%>
-    <%= link_to "降順", tasks_path(direction:'DESC'), class:"btn btn-light"%>
-    </div>
-    <% @task.each do |tasks| %>
-    <%= link_to(task_path(tasks.id), class: 'list-content') do %>
-    <div class="task_content mx-auto">
-        <%= tasks.name %><br>
-        <%= tasks.detail %><br>
-        <%= tasks.deadline %><br>
-        <%= tasks.progress_i18n %><br>
-            </div>
-                <% end %>
-    <% end %>
-    </div>
-        <div class="task_inP task_wrap">
-    <h2 class="text-center h4">
-    進行中
-    </h2>
-    </div>
-
-    <div class="task_done task_wrap">
-    <h2 class="text-center h4">
-    完了
-    </h2>
-    </div>
+    <%= link_to "昇順", tasks_path(direction:'ASC'), class:"btn btn-success"%>
+    <%= link_to "降順", tasks_path(direction:'DESC'), class:"btn btn-info"%>
     </div>
 </div>
+</div>
+<% if flash[:notice] %>
+<div class="alert alert-danger"><%= flash[:notice] %></div>
+<% end %>
+    <table class="table table-hover boards__table">
+        <thead class="thead-dark">
+            <tr>
+                <th>ID</th>
+                <th>タイトル</th>
+                <th>詳細</th>
+                <th>期限</th>
+                <th>進捗</th>
+            </tr>
+        </thead>
+        <tbody>
+            <% @task.each do |tasks| %>
+                <%= link_to(task_path(tasks.id)) do %>
+                    <tr>
+                        <td><%= tasks.id %></td>
+                        <td><%= tasks.name %></td>
+                        <td><%= tasks.detail %></td>
+                        <td><%= tasks.deadline %></td>
+                        <td><%= tasks.progress_i18n %></td>
+                    </tr>
+                <% end %>
+            <% end %>
+        </tbody>
+    </table>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,6 +16,7 @@
         <%= tasks.name %><br>
         <%= tasks.detail %><br>
         <%= tasks.deadline %><br>
+        <%= tasks.progress %><br>
             </div>
                 <% end %>
     <% end %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -10,6 +10,15 @@
   <%= f.label :detail %>
   <%= f.text_area :detail %>
   </p>
+  <p class="field">
+    <%= f.label :progress %><br />
+    <%= f.label :WAITING %>
+    <%= f.radio_button :progress, :WAITING %>
+    <%= f.label :WORKING %>
+    <%= f.radio_button :progress, :WORKING %>
+    <%= f.label :COMPLETED %>
+    <%= f.radio_button :progress, :COMPLETED %>
+  </p>
   <%= f.submit class:'btn btn-primary'%>
 <% end %>
 <%= link_to "戻る", tasks_path %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -14,11 +14,11 @@
   </div>
   <div class="field">
     <%= f.label :progress %><br />
-    <%= f.label :WAITING %>
+    <%= f.label "未着手" %>
     <%= f.radio_button :progress, :WAITING %>
-    <%= f.label :WORKING %>
+    <%= f.label "着手" %>
     <%= f.radio_button :progress, :WORKING %>
-    <%= f.label :COMPLETED %>
+    <%= f.label "完了" %>
     <%= f.radio_button :progress, :COMPLETED %>
   </div>
   <div class="form-group">

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -13,6 +13,10 @@
             <th>期限</th>
             <td><%= @task.deadline %></td>
         </tr>
+        <tr>
+            <th>進捗</th>
+            <td><%= @task.progress_i18n %></td>
+        </tr>
   </tbody>  
 </table>
 <%= link_to'編集',edit_task_path,class:"btn btn-white"%>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,6 @@ module App
     config.time_zone = 'Tokyo'
     config.i18n.default_locale = :ja
     config.generators.system_tests = nil
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,3 +205,9 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  enums:
+    task:
+      progress:
+        WAITING: 未着手
+        WORKING: 着手
+        COMPLETED: 完了

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,15 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      task: タスク
+    attributes:
+      task:
+        id: ID
+        name: タスク名
+        detail: 詳細
+        deadline: 期限
+        progress: 進捗
   date:
     abbr_day_names:
     - 日

--- a/config/locales/models/task/ja.yaml
+++ b/config/locales/models/task/ja.yaml
@@ -1,7 +1,0 @@
-ja:
-  enums:
-    task:  タスク
-      status: progress
-        WAITING: "未着手"  
-        WORKING: "着手"
-        COMPLETED: "完了"

--- a/config/locales/models/task/ja.yaml
+++ b/config/locales/models/task/ja.yaml
@@ -1,0 +1,7 @@
+ja:
+  enums:
+    task:  タスク
+      status: progress
+        WAITING: "未着手"  
+        WORKING: "着手"
+        COMPLETED: "完了"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   root 'tasks#index'
-  resources :tasks
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :tasks do
+    collection do
+      get 'search' => 'tasks#search'
+    end
+  end
 end

--- a/db/migrate/20200406022416_add_progress_to_tasks.rb
+++ b/db/migrate/20200406022416_add_progress_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddProgressToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :progress, :integer
+  end
+end

--- a/db/migrate/20200406132850_add_index_to_task.rb
+++ b/db/migrate/20200406132850_add_index_to_task.rb
@@ -1,0 +1,5 @@
+class AddIndexToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_06_022416) do
+ActiveRecord::Schema.define(version: 2020_04_06_132850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_04_06_022416) do
     t.datetime "updated_at", null: false
     t.date "deadline"
     t.integer "progress"
+    t.index ["name"], name: "index_tasks_on_name"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_11_085356) do
+ActiveRecord::Schema.define(version: 2020_04_06_022416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2019_11_11_085356) do
     t.text "detail"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "deadline"
+    t.integer "progress"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-if Rails.env == "development" || "test"
+if Rails.env == "development"
     (1..200).each do |i|
     Task.create(
         name: "タスク#{i}", 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 if Rails.env == "development" || "test"
-    (1..10).each do |i|
+    (1..200).each do |i|
     Task.create(
         name: "タスク#{i}", 
         detail: "タスク詳細表示タスク詳細表示#{i}", 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,13 +6,14 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-if Rails.env == "development"
-    (1..200).each do |i|
-    Task.create(
-        name: "タスク#{i}", 
-        detail: "タスク詳細表示タスク詳細表示#{i}", 
-        deadline: Faker::Date.between(from: 1.month.ago, to: Date.today),
-        progress: Faker::Number.between(from: 1, to: 3)
-    )
-    end
-end
+# テストで悪さするので一旦消えてもらう
+# if Rails.env == "development"
+#     (1..200).each do |i|
+#     Task.create(
+#         name: "タスク#{i}", 
+#         detail: "タスク詳細表示タスク詳細表示#{i}", 
+#         deadline: Faker::Date.between(from: 1.month.ago, to: Date.today),
+#         progress: Faker::Number.between(from: 1, to: 3)
+#     )
+#     end
+# end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,14 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+if Rails.env == "development" || "test"
+    (1..10).each do |i|
+    Task.create(
+        name: "タスク#{i}", 
+        detail: "タスク詳細表示タスク詳細表示#{i}", 
+        deadline: Faker::Date.between(from: 1.month.ago, to: Date.today),
+        progress: Faker::Number.between(from: 1, to: 3)
+    )
+    end
+end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe TasksController, type: :request do
+    before do
+        FactoryBot.create(:task1)
+        FactoryBot.create(:task2)
+    end
+    
+    describe "GET #index" do
+        context "when params_direction is DESC" do
+            it "データが降順で返されること" do
+                skip
+                get tasks_url, params: { direction: "DESC" }
+                expect(response.map(&:id)).to eq [2,1]
+            end
+        end
+
+        context "when params_direction is other than DESC" do
+            it "データが昇順で返されること" do
+                skip
+                get tasks_url, params: { direction: "ASC" }
+                expect(Task.map(&:id)).to eq [1,2]
+            end
+        end
+    end
+end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -9,17 +9,15 @@ RSpec.describe TasksController, type: :request do
     describe "GET #index" do
         context "when params_direction is DESC" do
             it "データが降順で返されること" do
-                skip
                 get tasks_url, params: { direction: "DESC" }
-                expect(response.map(&:id)).to eq [2,1]
+                expect(Task.order(deadline: "DESC").map(&:id)).to eq [2,1]
             end
         end
 
         context "when params_direction is other than DESC" do
             it "データが昇順で返されること" do
-                skip
                 get tasks_url, params: { direction: "ASC" }
-                expect(Task.map(&:id)).to eq [1,2]
+                expect(Task.order(deadline: "ASC").map(&:id)).to eq [1,2]
             end
         end
     end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     end
 
     factory :fixed_task, class: Task do
-        id { 2 }
+        id { 3 }
         name { '勉強' }
         detail { 'タスクの説明文ですテスト' }
         deadline { Date.today }

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,15 +1,25 @@
 FactoryBot.define do
-    factory :task do
-        sequence(:id) do |n| n end
-        sequence(:name) do |n| "タスク#{n}" end
-        sequence(:detail) do |n| "タスク#{n}の説明文です#{n}" end
-        sequence(:deadline, Date.today)
+    factory :task1, class: Task do
+        id {1}
+        name {"トレーニング"}
+        detail {"タスクの説明文ですタスクの説明文です"}
+        deadline {Date.today}
+        progress {1}
+    end
+
+    factory :task2, class: Task do
+        id {2}
+        name {"モブプロ"}
+        detail {"タスクの説明文ですタスクの説明文です"}
+        deadline {Date.tomorrow}
+        progress {2}
     end
 
     factory :fixed_task, class: Task do
         id { 2 }
         name { '勉強' }
         detail { 'タスクの説明文ですテスト' }
-        deadline { '2020-04-04' }
+        deadline { Date.today }
+        progress {1}
     end
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,15 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-    let(:fixed_task){ FactoryBot.create(:fixed_task) }
+    describe "validation" do
+        let(:fixed_task) {FactoryBot.create(:fixed_task) } 
 
-    it "factoryでデータが作られること" do
-        task_instance = Task.new(
-                id: 2,
-                name: "勉強",
-                detail: "タスクの説明文ですテスト",
-                deadline: '2020-04-04',
-            )
-        expect(fixed_task) .to eq task_instance
+        describe "valid" do
+            it "有効なデータであること" do
+                expect(fixed_task).to be_valid
+            end
+        end
+
+        describe "invalid" do
+            it "nameが空の場合" do
+                fixed_task.name = ""
+                expect(fixed_task).to be_invalid
+            end
+    
+            it "detailが10文字以下の場合" do
+                fixed_task.detail = "アイウエオ"
+                expect(fixed_task).to be_invalid
+            end
+        end
     end
-end
+
+        describe "search" do
+            let(:task1) {FactoryBot.create(:task1)} 
+            let(:task2) {FactoryBot.create(:task2)}
+
+            
+            describe "トレーニングで検索して該当の値を返す" do
+                it "return task1" do
+                    expect(Task.name_like("トレーニング")).to include(task1)
+                end
+            end
+
+            describe "未着手で検索して値を返す" do
+                it "return task2" do
+                    expect(Task.progress_is("WORKING")).to include(task2)
+                end
+            end
+        end
+        
+    end
+

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -26,17 +26,30 @@ RSpec.describe Task, type: :model do
         describe "search" do
             let(:task1) {FactoryBot.create(:task1)} 
             let(:task2) {FactoryBot.create(:task2)}
-
-            
-            describe "トレーニングで検索して該当の値を返す" do
-                it "return task1" do
-                    expect(Task.name_like("トレーニング")).to include(task1)
+            let(:params) { {"name" => name, "progress" => progress } } 
+            context "when params is nil" do
+                context "nilで検索した場合全てのデータを返す" do
+                    it "return task1" do
+                        expect(Task.search(nil)).to include(task1,task2)
+                    end
                 end
             end
 
-            describe "未着手で検索して値を返す" do
-                it "return task2" do
-                    expect(Task.progress_is("WORKING")).to include(task2)
+            context "when params exist" do
+                context "トレーニングで検索して該当の値を返す" do
+                    let(:name) { "トレーニング" } 
+                    let(:progress) { "" } 
+                    it "return task1" do
+                        expect(Task.search(params)).to include(task1)
+                    end
+                end
+    
+                context "未着手で検索して値を返す" do
+                    let(:name) { "" } 
+                    let(:progress) { "WORKING" } 
+                    it "return task2" do
+                        expect(Task.search(params)).to include(task2)
+                    end
                 end
             end
         end


### PR DESCRIPTION
## 万葉
万葉のどのステップに着手しているのかを書く

**ステップ17: ステータスを追加して、検索できるようにしよう**

1. ステータス（未着手・着手中・完了）を追加してみましょう
2. 一覧画面でタイトルとステータスで検索ができるようにしましょう
3. 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
4. 検索インデックスを貼りましょう
5. 検索に対してmodel specを追加してみましょう（system specも拡充しておきましょう）

## 処理概要
ステータスを追加（enum progressカラム）
一覧画面から検索パラメーターを受け取り、タイトルとステータスで検索したデータを返す。
nameにindexを貼り検索速度改善
一覧画面のデザインを修正

## 特記

## 動作確認観点
実装上、動作確認時に確認すべき箇所がある場合は記載してください
検索部分のコントローラーとモデルの実装をレビューいただきたです

